### PR TITLE
Use `rescript` compiler instead of `bs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
   ],
   "scripts": {
     "format:most": "prettier --write \"**/*.{md,json,js,css}\"",
-    "format:re": "find . -name \"*.re\" -or -name \"*.rei\" | grep -v \"node_modules\" | xargs bsrefmt --in-place",
+    "format:re": "find . -name \"*.res\" -or -name \"*.resi\" | grep -v \"node_modules\" | xargs rescript format",
     "format": "yarn format:most && yarn format:re",
-    "re:start": "bsb -make-world -w",
-    "re:build": "bsb -make-world",
-    "re:clean-build": "bsb -clean-world -make-world",
+    "re:start": "rescript build -w",
+    "re:build": "rescript build",
+    "re:clean-build": "rescript clean && rescript build",
     "start": "yarn re:start",
     "build": "yarn re:build",
     "test": "yarn re:clean-build",
     "release": "npmpub"
   },
   "devDependencies": {
-    "bs-platform": "^9.0.0",
+    "rescript": "^9.1.4",
     "husky": "^4.0.0",
     "lint-staged": "^10.0.0",
     "npmpub": "^5.0.0",
@@ -53,8 +53,8 @@
     "*.{md,json,js,css}": [
       "prettier --write"
     ],
-    "*.{re,rei}": [
-      "bsrefmt --in-place"
+    "*.{res,resi}": [
+      "rescript format"
     ]
   },
   "husky": {

--- a/src/ReactNativeWebView.res
+++ b/src/ReactNativeWebView.res
@@ -78,31 +78,31 @@ module WebViewDownloadEvent = {
 }
 
 module WebViewErrorEvent = {
-  type payload = Js.t<webViewError>
+  type payload = webViewError
   include Event.SyntheticEvent({
     type _payload = payload
   })
 }
 module WebViewHttpErrorEvent = {
-  type payload = Js.t<webViewHttpError>
+  type payload = webViewHttpError
   include Event.SyntheticEvent({
     type _payload = payload
   })
 }
 module WebViewMessageEvent = {
-  type payload = Js.t<webViewMessage>
+  type payload = webViewMessage
   include Event.SyntheticEvent({
     type _payload = payload
   })
 }
 module WebViewNavigationEvent = {
-  type payload = Js.t<webViewNavigation>
+  type payload = webViewNavigation
   include Event.SyntheticEvent({
     type _payload = payload
   })
 }
 module WebViewProgressEvent = {
-  type payload = Js.t<webViewNativeProgressEvent>
+  type payload = webViewNativeProgressEvent
   include Event.SyntheticEvent({
     type _payload = payload
   })
@@ -114,14 +114,14 @@ module WebViewRenderProcessGone = {
   })
 }
 module WebViewTerminatedEvent = {
-  type payload = Js.t<webViewNativeEvent>
+  type payload = webViewNativeEvent
   include Event.SyntheticEvent({
     type _payload = payload
   })
 }
 
 module UnionCallback = ReactNativeWebView_UnionCallback.Make({
-  type union = Js.t<webViewNavigationOrError>
+  type union = webViewNavigationOrError
   type navigationEvent = WebViewNavigationEvent.t
   type errorEvent = WebViewErrorEvent.t
 })
@@ -194,9 +194,9 @@ external make: (
   ~onLoadProgress: WebViewProgressEvent.t => unit=?,
   ~onLoadStart: WebViewNavigationEvent.t => unit=?,
   ~onMessage: WebViewMessageEvent.t => unit=?,
-  ~onNavigationStateChange: Js.t<webViewNavigation> => unit=?,
+  ~onNavigationStateChange: webViewNavigation => unit=?,
   ~onRenderProcessGone: WebViewRenderProcessGone.t => unit=?,
-  ~onShouldStartLoadWithRequest: Js.t<webViewShouldStartLoadWithRequest> => bool=?,
+  ~onShouldStartLoadWithRequest: webViewShouldStartLoadWithRequest => bool=?,
   ~originWhitelist: array<string>=?,
   ~overScrollMode: [#never | #always | #content]=?,
   ~pagingEnabled: bool=?,

--- a/src/ReactNativeWebView_DataDetectorTypes.resi
+++ b/src/ReactNativeWebView_DataDetectorTypes.resi
@@ -1,28 +1,28 @@
 type t
 
-@bs.inline("phoneNumber")
+@inline("phoneNumber")
 let phoneNumber: t
 
-@bs.inline("link")
+@inline("link")
 let link: t
 
-@bs.inline("address")
+@inline("address")
 let address: t
 
-@bs.inline("calendarEvent")
+@inline("calendarEvent")
 let calendarEvent: t
 
-@bs.inline("none")
+@inline("none")
 let none: t
 
-@bs.inline("all")
+@inline("all")
 let all: t
 
-@bs.inline("trackingNumber")
+@inline("trackingNumber")
 let trackingNumber: t
 
-@bs.inline("flightNumber")
+@inline("flightNumber")
 let flightNumber: t
 
-@bs.inline("lookupSuggestion")
+@inline("lookupSuggestion")
 let lookupSuggestion: t

--- a/src/ReactNativeWebView_DecelerationRate.resi
+++ b/src/ReactNativeWebView_DecelerationRate.resi
@@ -2,8 +2,8 @@ type t
 
 external value: float => t = "%identity"
 
-@bs.inline("normal")
+@inline("normal")
 let normal: t
 
-@bs.inline("fast")
+@inline("fast")
 let fast: t

--- a/src/ReactNativeWebView_NavigationType.resi
+++ b/src/ReactNativeWebView_NavigationType.resi
@@ -1,19 +1,19 @@
 type t
 
-@bs.inline("click")
+@inline("click")
 let click: t
 
-@bs.inline("formsubmit")
+@inline("formsubmit")
 let formsubmit: t
 
-@bs.inline("backforward")
+@inline("backforward")
 let backforward: t
 
-@bs.inline("reload")
+@inline("reload")
 let reload: t
 
-@bs.inline("formresubmit")
+@inline("formresubmit")
 let formresubmit: t
 
-@bs.inline("other")
+@inline("other")
 let other: t

--- a/src/ReactNativeWebView_UnionCallback.bs.js
+++ b/src/ReactNativeWebView_UnionCallback.bs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Curry = require("bs-platform/lib/js/curry.js");
+var Curry = require("rescript/lib/js/curry.js");
 var Event$ReactNative = require("rescript-react-native/src/apis/Event.bs.js");
 var NativeElement$ReactNative = require("rescript-react-native/src/elements/NativeElement.bs.js");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,11 +263,6 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
-bs-platform@^9.0.0:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.2.tgz#a6eac70eb8924a322556dacaccbfbc9b2a0d3a37"
-  integrity sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==
-
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -1125,6 +1120,11 @@ rescript-react-native@^0.64.3:
   version "0.64.3"
   resolved "https://registry.yarnpkg.com/rescript-react-native/-/rescript-react-native-0.64.3.tgz#8fd11a2681cfdd65c02f0ff620186e5adf0c6854"
   integrity sha512-PjGDkV3RYiCTk4hCZyaKtZJV69By0AmJuzWyuHZONdeCB0q3DwjVJtA73gu6+jBrdl0OWon6UdXaVRXhhR47cQ==
+
+rescript@^9.1.4:
+  version "9.1.4"
+  resolved "https://registry.yarnpkg.com/rescript/-/rescript-9.1.4.tgz#1eb126f98d6c16942c0bf0df67c050198e580515"
+  integrity sha512-aXANK4IqecJzdnDpJUsU6pxMViCR5ogAxzuqS0mOr8TloMnzAjJFu63fjD6LCkWrKAhlMkFFzQvVQYaAaVkFXw==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Hi!
This is something I would need for a project of mine. 

We use `rescript` compiler and it fails to compile this package due to some differences. ReScript doesn't allow `Js.t<_some_record_type>`.

Currently, we patched package with the changes I made in `ReactNativeWebView.res` and it works normally, but we would like to get rid of the patch.

Closes #2 